### PR TITLE
feature/blockMask

### DIFF
--- a/+nigeLab/+defaults/doActions.m
+++ b/+nigeLab/+defaults/doActions.m
@@ -6,28 +6,50 @@ function pars = doActions(name)
 %  pars = nigeLab.defaults.doActions('doMethodName');  Return specific flag
 %
 %  Each field is the name of some 'doMethod'
-%  Each field contains a cell array of fields that must evaluate to 'true'
-%  from `updateParams` method of Block in order for that `doMethod` to run
-%  correctly.
+%  Each field contains a struct with the following fields:
+%     
+%     * 'required' :  cell array of fields that must evaluate to 'true'
+%                     from `updateParams` method of Block. Otherwise,
+%                     that `doMethod` will throw an error when called.
+%  
+%     * 'enabled'  :  true or false. If false, will be greyed out in
+%                     nigeLab.libs.DashBoard.
 
 %%
 pars = struct;
-
-pars.doAutoClustering = {'Spikes'};
-pars.doBehaviorSync = {'Video'};
-pars.doEventDetection = {};  % Can be run without video (dig/analog stream)
-pars.doEventHeaderExtraction = {'Video'};
-pars.doLFPExtraction = {'Raw'};
-pars.doRawExtraction = {};
-pars.doReReference = {'Filt'};
-pars.doSD = {'CAR'};
-pars.doUnitFilter = {'Raw'};
-pars.doVidInfoExtraction = {'Video'};
-pars.doVidSyncExtraction = {'Video'};
+pars.doAutoClustering = doAction({'Spikes'},true);
+pars.doBehaviorSync= doAction({'Video'});
+pars.doEventDetection = doAction();
+pars.doEventHeaderExtraction = doAction({'Video'});
+pars.doLFPExtraction = doAction({'Raw'},true);
+pars.doRawExtraction = doAction({},true);
+pars.doReReference = doAction({'Filt'},true);
+pars.doSD = doAction({'CAR'},true);
+pars.doUnitFilter = doAction({'Raw'},true);
+pars.doVidInfoExtraction = doAction({'Video'});
+pars.doVidSyncExtraction = doAction({'Video'});
 
 if nargin > 0
    pars = pars.(name);
 end
 
+   function doStruct = doAction(required,en)
+      %DOACTION  Helper function to create doAction struct
+      %
+      %  doStruct = doAction({'field1',...,'fieldk'}); Sets required fields
+      %  doStruct = doAction(__,true); Sets 'enabled' to true
+      
+      if nargin < 1
+         required = {};
+      end
+      
+      if nargin < 2
+         en = false;
+      end
+      
+      doStruct = struct;
+      doStruct.required = required;
+      doStruct.enabled = en;
+   end
 
 end

--- a/+nigeLab/+defaults/nigelColors.m
+++ b/+nigeLab/+defaults/nigelColors.m
@@ -1,8 +1,12 @@
 function [Col] = nigelColors(input,source)
 %NIGELCOLORS default colors for nigeLab
+%  
 %   returns one or more colors depending on the input
 %
 %   input,  numeric array or string.
+%
+%  To get a list of input color options, call as:
+%  <strong>>> nigeLab.defaults.nigelColors('help'); </strong>
 %
 % ---------------------------------
 %   Col,   Color matrix. Nx3, where N is nunmel(input)
@@ -21,32 +25,57 @@ switch nargin
          return;
       end
       if iscell(input),Col=nigeLab.defaults.nigelColors(input{1});return;end
-      switch input
+      switch lower(input)
+         case {'help','opts','options'}
+            fprintf(1,'<strong>''primary'',''g'',''hl''</strong> -> ');
+            nigeLab.utils.cprintf([30, 185, 128]./255,'green\n');
+            fprintf(1,'<strong>''secondary'',''dg'',''enable'',''button''</strong> -> ');
+            nigeLab.utils.cprintf([4, 93, 86]./255,'dark green\n');
+            fprintf(1,'<strong>''disable'',''ddg''</strong> -> ');
+            nigeLab.utils.cprintf([4, 55, 32]./255,'darker green\n');
+            fprintf(1,'<strong>''tertiary'',''o''</strong> -> ');
+            nigeLab.utils.cprintf([255, 104, 89]./255,'orange\n');
+            fprintf(1,'<strong>''quaternary'',''y''</strong> -> ');
+            nigeLab.utils.cprintf([255, 207, 68]./255,'yellow\n');
+            fprintf(1,'<strong>''onprimary'',''k''</strong> -> ');
+            nigeLab.utils.cprintf([0 0 0],'black\n');
+            fprintf(1,'<strong>''background'',''bg''</strong> -> ');
+            nigeLab.utils.cprintf([18, 18, 18]./255,'nearly black\n');
+            fprintf(1,'<strong>''surface'',''sfc'',''dark''</strong> -> ');
+            nigeLab.utils.cprintf([55, 56, 58]./255,'dark gray\n');
+            fprintf(1,'<strong>''disabletext'',''med''</strong> -> ');
+            nigeLab.utils.cprintf([125, 125, 125]./255,'medium gray\n');
+            fprintf(1,'<strong>''light'',''light_grey''</strong> -> ');
+            nigeLab.utils.cprintf([220, 220, 220]./255,'light gray\n');
+            fprintf(1,'''onsecondary'',''onbutton'',''onsurface'',''enabletext'',''w'' -> ');
+            nigeLab.utils.cprintf([1 1 1],'white\n');
+            fprintf(1,'<strong>''r'',''red''</strong> -> ');
+            nigeLab.utils.cprintf([240, 25, 25]./255,'red\n');
+            fprintf(1,'<strong>''m'',''magenta''</strong> -> ');
+            nigeLab.utils.cprintf([240, 25, 240]./255,'magenta\n');
+            fprintf(1,'<strong>''b'',''blue''</strong> -> ');
+            nigeLab.utils.cprintf([67 129 193]./255,'blue\n');
          case {'primary','g','green','highlight','hl',1}
             Col = [30, 185, 128]./255;   % green
          case {'secondary','dg','darkgreen','button','enable',2}
             Col = [4, 93, 86]./255;      % dark green
          case {'disable','ddg','darkergreen',2.5}
-            Col = [4, 55, 32]./255;      % dark green
+            Col = [4, 55, 32]./255;      % darker green
          case {'tertiary','o','orange',3}
             Col = [255, 104, 89]./255;   % orange
          case {'quaternary','y','yellow',4}
             Col = [255, 207, 68]./255;   % yellow
-         case {'onprimary','k','black',1.1}
-            Col = [0, 0, 0]./255; % black
-         case {'onsecondary','w','white','onbutton','enabletext',2.1} 
-            Col = [255, 255, 255]./255; % white
-         case {'disabletext','med_gray','med_grey','med'}
-            Col = [125, 125, 125]./255;
-         case {'ontertiary',3.1}
-            Col = [0, 0, 0]./255; % black
-         case {'onquaternary',4.1}
+         case {'onprimary','k','black','ontertiary','onquaternary',1.1}
             Col = [0, 0, 0]./255; % black
          case {'background','bg',0}
             Col = [18, 18, 18]./255; % nearly black
          case {'surface','sfc','dark_gray','dark_grey','dark',0.1}
             Col = [55, 56, 58]./255; % dark grey
-         case {'onsurface','onsfc',0.2}
+         case {'disabletext','med_gray','med_grey','med'}
+            Col = [125, 125, 125]./255;
+         case {'light_grey','light_gray','light'}
+            Col = [220, 220, 220]./255; % light grey
+         case {'onsecondary','w','white','onbutton','enabletext','onsurface','onsfc',2.1,0.2} 
             Col = [255, 255, 255]./255; % white
          case {'r','red'}
             Col = [240, 25, 25]./255; % red
@@ -54,8 +83,6 @@ switch nargin
             Col = [240, 25, 240]./255; % magenta
          case {'b','blue'}
             Col = [67 129 193]./255; % blue
-         case {'light_grey','light_gray','light'}
-            Col = [220, 220, 220]./255; % light grey
          otherwise
             Col = [0, 0, 0]./255;
             warning('%s is not a recognized nigelColors option.',input);

--- a/+nigeLab/+evt/treeSelectionChanged.m
+++ b/+nigeLab/+evt/treeSelectionChanged.m
@@ -1,0 +1,103 @@
+classdef (ConstructOnLoad) treeSelectionChanged < event.EventData
+%TREESELECTIONCHANGED   Event for notifying listeners that current
+%                       selection has changed in Tank/Animal/Block tree of
+%                       nigeLab.libs.DashBoard
+%
+%  evt = nigeLab.evt.treeSelectionChanged(block,animal);
+%
+%  TREESELECTIONCHANGED Methods:
+%     treeSelectionChanged  -  Class constructor
+%
+%  TREESELECTIONCHANGED Properties:
+%     Animal - nigeLab.Animal scalar or array of animals in this selection
+%
+%     Block - nigeLab.Block scalar or array of blocks in this selection
+%
+%     Tank - nigeLab.Tank scalar; hierarchical top-level container
+%     
+%     SelectionIndex - [animalIndex, blockIndex] 2-column matrix that
+%        indexes .Tank. i.e. 
+%        >> evt.Block = evt.Tank{evt.SelectionIndex}; % or
+%        >> evt.Animal = evt.Tank{evt.SelectionIndex(:,1)};
+
+   properties
+      Animal  nigeLab.Animal % Animal or array of animals in this selection
+      Block   nigeLab.Block  % Block or array of blocks in this selection
+      Tank    nigeLab.Tank   % Tank associated with this selection
+      SelectionIndex  double % [animalIndex, blockIndex]
+   end
+
+   methods (Access = public)
+      function evt = treeSelectionChanged(tankObj,selectionIndex)
+         %TREESELECTIONCHANGED   Event for notifying listeners that current
+         %                       selection has changed in Tank/Animal/Block
+         %                       tree of nigeLab.libs.DashBoard
+         %
+         %  tankObj = nigeLab.Tank();
+         %  evt = nigeLab.evt.treeSelectionChanged(tankObj,selectionIndex);
+         %
+         %  blockObj = tankObj{selectionIndex};
+         %  animalObj = tankObj{unique(selectionIndex(:,1))};
+         
+         evt.Tank = tankObj;
+         switch size(selectionIndex,2)
+            case 0
+               %% No indexing was given (indexing is from Tank select)
+               evt.initAll();
+               
+            case 1
+               %% Only Animals indexing was given
+               evt.initAll(selectionIndex);
+            case 2
+               %% Normal case
+               evt.Animal = tankObj.Animals(unique(selectionIndex(:,1)));
+               evt.Block = tankObj{selectionIndex(:,1),selectionIndex(:,2)};
+               evt.SelectionIndex = selectionIndex;
+            case 3
+               %% nigeLab.libs.DashBoard.SelectionIndex was given
+               if selectionIndex(1,2)==0 % Then tank is selected
+                  evt.initAll();
+                  
+               else % Otherwise, relatively normal
+                  evt.SelectionIndex = selectionIndex(:,[2,3]);
+                  evt.Block = tankObj{evt.SelectionIndex(:,1),...
+                                      evt.SelectionIndex(:,2)};
+                  iA = unique(evt.SelectionIndex(:,1));
+                  evt.Animal = tankObj.Animals(iA);
+               end
+            otherwise
+               error(['nigeLab:' mfilename ':InvalidInputSize'],...
+                   ['Expected selectionIndex to have between ' ...
+                    '0 and 3 columns (it has %g)'],size(selectionIndex,2));
+         end
+      end
+   end
+   
+   methods (Access = private)
+      % Method to initialize ALL Animals/Blocks in Tank
+      function initAll(evt,animalIndices)
+         %INITALL Initializes evt with ALL animals/blocks in tank
+         %
+         %  evt.initAll();
+         %  evt.initAll(animalIndices);  Init with subset of animals/all
+         %                               blocks for those animals
+         
+         if nargin < 2
+            evt.Animal = evt.Tank.Animals;
+         else
+            evt.Animal = evt.Tank.Animals(unique(animalIndices));
+         end
+         selectionIndex = [];
+         iA = 0;
+         for a = evt.Animal
+            iA = iA + 1;
+            evt.Block = [evt.Block, a.Blocks];
+            n = numel(a.Blocks);
+            selectionIndex = [selectionIndex; ...
+               ones(n,1)*iA, (1:n)']; %#ok<*AGROW>
+         end
+         evt.SelectionIndex = selectionIndex;
+      end
+   end
+   
+end

--- a/+nigeLab/@Animal/findByKey.m
+++ b/+nigeLab/@Animal/findByKey.m
@@ -1,0 +1,77 @@
+function [a,idx] = findByKey(animalObjArray,keyStr,keyType)
+%FINDBYKEY  Returns the animal corresponding to keyStr from array
+%
+%  example:
+%  animalObjArray = tankObj{:}; % Get all animals from tank
+%  a = findByKey(animalObjArray,keyStr); % Find specific animal
+%  [a,idx] = findByKey(animalObjArray,keyStr); % Return index into
+%                                   animal array as well
+%
+%  a = findByKey(animalObjArray,privateKey,'Private');
+%  --> By default, uses 'Public' key to find the Block; this would
+%      find the associated 'Private' key that matches the contents
+%      of privateKey.
+%
+%  keyStr : Can be char array or cell array. If it's a cell array,
+%           then b is returned as a row vector with number of
+%           elements corresponding to number of cell elements.
+%
+%  keyType : (optional) Char array. Should be 'Private' or
+%                          'Public' (default if not specified)
+
+if nargin < 2
+   error(['nigeLab:' mfilename ':tooFewInputs'],...
+      'Need to provide animal array and hash key at least.');
+else
+   if isa(keyStr,'nigeLab.Animal')
+      keyStr = getKey(keyStr);
+   end
+   
+   if ~iscell(keyStr)
+      keyStr = {keyStr};
+   end
+end
+
+if nargin < 3
+   keyType = 'Public';
+else
+   if ~ischar(keyType)
+      error(['nigeLab:' mfilename ':badInputType2'],...
+         'Unexpected class for ''keyType'' (%s): should be char.',...
+         class(keyType));
+   end
+   % Ensure it is the correct capitalization
+   keyType = lower(keyType);
+   keyType(1) = upper(keyType(1));
+   if ~ismember(keyType,{'Public','Private'})
+      error(['nigeLab:' mfilename ':badKeyType'],...
+         'keyType must be ''Public'' or ''Private''');
+   end
+end
+
+a = nigeLab.Animal.Empty(); % Initialize empty Animal array
+idx = [];
+
+% Loop through array of animals, breaking the loop if an actual
+% animal is found. If animal index is greater than the size of
+% array, then returns an empty double ( [] )
+nAnimalKeys = numel(keyStr);
+if nAnimalKeys > 1
+   cur = 0;
+   while ((numel(a) < numel(keyStr)) && (cur < nAnimalKeys))
+      cur = cur + 1;
+      [a_tmp,idx_tmp] = findByKey(animalObjArray,keyStr(cur),keyType);
+      a = [a,a_tmp];%#ok<*AGROW>
+      idx = [idx, idx_tmp];
+   end
+   return;
+end
+
+% If any of the keys match, return the corresponding block.
+thisKey = getKey(animalObjArray,keyType);
+idx = find(ismember(thisKey,keyStr),1,'first');
+if ~isempty(idx)
+   a = animalObjArray(idx);
+end
+
+end

--- a/+nigeLab/@Animal/parseProbes.m
+++ b/+nigeLab/@Animal/parseProbes.m
@@ -2,9 +2,13 @@ function parseProbes(animalObj)
 %PARSEPROBES  Parse .Probes property struct fields using child "blocks"
 %
 %  animalObj.parseProbes();
+%
+%  In use as a listener callback (handle is animalObj.PropListener(3)).
+%  Also called in `nigeLab.Animal/addChildBlock` at the end, if the mask
+%  size has increased or if the number of non-empty Child Blocks is equal
+%  to the mask size.
 
 animalObj.updateParams('Animal');
-
 if isempty(animalObj.Blocks)
    nigeLab.utils.cprintf('Comments',...
       'No child blocks of Animal: %s -- skipped probe parsing\n',...
@@ -15,6 +19,7 @@ end
 % Get all possible unique probe/channel number combinations for this Animal
 channelID = [];
 B = animalObj.Blocks(~isempty(animalObj.Blocks));
+B = B(animalObj.BlockMask);
 for b = B
    if isempty(b)
       continue;

--- a/+nigeLab/@Block/checkActionIsValid.m
+++ b/+nigeLab/@Block/checkActionIsValid.m
@@ -40,7 +40,7 @@ if ~isfield(blockObj.Pars.doActions,doName)
       nigeLab.utils.getNigeLink('nigeLab.defaults.doActions'));
 end
 
-Fields = blockObj.Pars.doActions.(doName);
+Fields = blockObj.Pars.doActions.(doName).required;
 if isempty(Fields)
    return; % No requirements; proceed
 end

--- a/+nigeLab/@Block/doAutoClustering.m
+++ b/+nigeLab/@Block/doAutoClustering.m
@@ -41,6 +41,7 @@ else
    str = sprintf('AutoClustering-(%s)',par.MethodName);
 end
 blockObj.reportProgress(str,0,'toWindow');
+curCh = 0;
 for iCh = chan
    % load spikes and classes
    inspk = blockObj.getSpikeFeatures(iCh,unit);
@@ -81,10 +82,9 @@ for iCh = chan
    saveClusters(blockObj,classes,iCh,temp);
    
    % report progress to the user
-   curCh = find(chan == iCh,1,'first');
+   curCh = curCh+1;
    pct = round((curCh/numel(chan)) * 100);
    blockObj.updateStatus('Clusters',true,iCh);
-   blockObj.updateStatus('Sorted',true,iCh);
    blockObj.reportProgress(str,pct,'toWindow');
    blockObj.reportProgress(par.MethodName,pct,'toEvent',par.MethodName);
 end

--- a/+nigeLab/@Block/findByKey.m
+++ b/+nigeLab/@Block/findByKey.m
@@ -1,0 +1,78 @@
+function [b,idx] = findByKey(blockObjArray,keyStr,keyType)
+%FINDBYKEY  Returns the block corresponding to keyStr from array
+%
+%  example:
+%  blockObjArray = tankObj{:,:}; % Get all blocks from tank
+%  b = findByKey(blockObjArray,keyStr); % Find specific block
+%  [b,idx] = findByKey(blockObjArray,keyStr);  % Returns block and
+%                 corresponding index into array that relates to
+%                 that block (useful for arrays that are matched
+%                 with block).
+%
+%  b = findByKey(blockObjArray,privateKey,'Private');
+%  --> By default, uses 'Public' key to find the Block; this would
+%      find the associated 'Private' key that matches the contents
+%      of privateKey.
+%
+%  keyStr : Can be char array or cell array. If it's a cell array,
+%           then b is returned as a row vector with number of
+%           elements corresponding to number of cell elements.
+%
+%  keyType : (optional) Char array. Should be 'Private' or
+%                          'Public' (default if not specified)
+
+if nargin < 2
+   error(['nigeLab:' mfilename ':tooFewInputs'],...
+      'Need to provide block array and hash key at least.');
+else
+   if isa(keyStr,'nigeLab.Block')
+      keyStr = getKey(keyStr);
+   end
+   if ~iscell(keyStr)
+      keyStr = {keyStr};
+   end
+end
+
+if nargin < 3
+   keyType = 'Public';
+else
+   if ~ischar(keyType)
+      error(['nigeLab:' mfilename ':badInputType2'],...
+         'Unexpected class for ''keyType'' (%s): should be char.',...
+         class(keyType));
+   end
+   % Ensure it is the correct capitalization
+   keyType = lower(keyType);
+   keyType(1) = upper(keyType(1));
+   if ~ismember(keyType,{'Public','Private'})
+      error(['nigeLab:' mfilename ':badKeyType'],...
+         'keyType must be ''Public'' or ''Private''');
+   end
+end
+
+b = nigeLab.Block.Empty(); % Initialize empty Block array
+idx = [];
+
+% Loop through array of blocks, breaking the loop if an actual
+% block is found. If block index is greater than the size of
+% array, then returns an empty double ( [] )
+nBlockKeys = numel(keyStr);
+if nBlockKeys > 1
+   cur = 0;
+   while ((numel(b) < numel(keyStr)) && (cur < nBlockKeys))
+      cur = cur + 1;
+      [b_tmp,idx_tmp] = findByKey(blockObjArray,keyStr(cur),keyType);
+      b = [b,b_tmp]; %#ok<*AGROW>
+      idx = [idx,idx_tmp];
+   end
+   return;
+end
+
+% If any of the keys match, return the corresponding block.
+thisKey = getKey(blockObjArray,keyType);
+idx = find(ismember(thisKey,keyStr),1,'first');
+if ~isempty(idx)
+   b = blockObjArray(idx);
+end
+
+end

--- a/+nigeLab/@Block/getStatus.m
+++ b/+nigeLab/@Block/getStatus.m
@@ -52,11 +52,20 @@ if ~isscalar(blockObj)
             case 'Channels'
                if iscell(field)
                   status = false(numel(blockObj),numel(field));
+                  if numel(field) > 1
+                     for i = 1:numel(blockObj)
+                        status(i,:) = blockObj(i).getStatus(field);
+                     end
+                  else
+                     for i = 1:numel(blockObj)
+                        status(i) = all(blockObj(i).getStatus(field));
+                     end
+                  end
                else
                   status = false(numel(blockObj),blockObj(1).NumChannels);
-               end
-               for i = 1:numel(blockObj)
-                  status(i,:) = blockObj(i).getStatus(field);
+                  for i = 1:numel(blockObj)
+                     status(i,:) = blockObj(i).getStatus(field);
+                  end
                end
             otherwise
                
@@ -109,7 +118,6 @@ switch nargin
          else
             return;
          end
-         return;
       end
       if isfield(blockObj.Pars,'Video') && strcmp(field,'Video')
          if ~isempty(blockObj.Pars.Video.ScoringEventFieldname)
@@ -138,9 +146,9 @@ switch nargin
                      size(blockObj.Scoring.Video,1)},'Complete');
                otherwise
                   % do nothing
-            end
-         end
-      end
+            end % switch field
+         end % ~isempty(blockObj.Pars.Video.ScoringEventFieldname
+      end % isfield 'Video' and field is 'Video'
       
    case 3 % If channel is given (3 inputs, including blockObj)
       status = parseStatus(blockObj,field);

--- a/+nigeLab/@Tank/Tank.m
+++ b/+nigeLab/@Tank/Tank.m
@@ -53,8 +53,9 @@ classdef Tank < handle
    %% PROPERTIES
    % Public get & set, SetObservable as well
    properties (GetAccess = public, SetAccess = public, SetObservable)
-      Name    char               % Name of experiment (TANK)
-      Animals nigeLab.Animal     % Handle array to Children
+      Name        char               % Name of experiment (TANK)
+      Animals     nigeLab.Animal     % Handle array to Children
+      AnimalMask  logical            % Logical array for masking child animals
    end
 
    % Has to be set by method of Tank, but can be accessed publically
@@ -550,16 +551,17 @@ classdef Tank < handle
                in = load(fullfile(A(ii).folder,A(ii).name));
                a.addAnimal(in.animalObj,ii);
             end
-            a.addListeners();
-            a.checkParallelCompatibility();
-            b = a;
-            return;
          else
-            a.addListeners();
-            a.checkParallelCompatibility();
-            b = a;
-            return;
+            % Do not expect this to be the case.
+            warning('Tank (%s) was loaded with non-empty Animals',a.Name);
          end
+         a.addListeners();
+         a.checkParallelCompatibility();
+         % Check if AnimalMask is initialized; if it is not, set it
+         if isempty(a.AnimalMask)
+            a.AnimalMask = true(size(a.Animals)); % init all to true
+         end
+         b = a;
          
       end
       


### PR DESCRIPTION
* Added `.BlockMask` property to `nigeLab.Animal`, corresponding `.IsMasked` logical flag to `nigeLab.Block`, and listeners that associate the two. `nigeLab.libs.DashBoard` updates the uicontextmenu enable state dynamically based on the `.IsMasked` property of Block. 

* Added `Enable` uicontextmenu item at top of the `nigeLab.libs.DashBoard` context menu list, which has a separator between it and the `doMethod` menu item list. All menu items are now listed as (Private) properties of `nigeLab.libs.DashBoard`. `Enable` item toggles the `.IsMasked` property of each selected Block. When any selected Block has `.IsMasked == false`, then the `doMethod` list is disabled and the selection background color on the tree turns red.

* Added `treeSelectionChanged` event class, which has property handles to the currently-selected Blocks, unique Animals those correspond to, and the Tank itself. It also has a `.SelectionIndex` property that can be used as `.Block = .Tank{.SelectionIndex}`. The event is associated with `TreeSelectionChanged` event that is issued any time the uitree is clicked in the `nigeLab.libs.DashBoard` interface.

* Added parsing of "unified" child channel masks based on `Animal.BlockMask`, so that unwanted Blocks can be toggled to "disabled" using the uicontextmenu and this will update the mask array.
  + Note that this could cause conflicts in the future if individual Block channel masks are set, that has not been addressed yet.

* Added `Sort` to uicontextmenu from `nigeLab.libs.DashBoard` interface.