### PR TITLE
Improved Mask

### DIFF
--- a/+nigeLab/+defaults/nigelColors.m
+++ b/+nigeLab/+defaults/nigelColors.m
@@ -27,7 +27,7 @@ switch nargin
       if iscell(input),Col=nigeLab.defaults.nigelColors(input{1});return;end
       switch lower(input)
          case {'help','opts','options'}
-            fprintf(1,'<strong>''primary'',''g'',''hl''</strong> -> ');
+            fprintf(1,'<strong>''primary'',''g'',''enableobj'',''goodobj'',''hl''</strong> -> ');
             nigeLab.utils.cprintf([30, 185, 128]./255,'green\n');
             fprintf(1,'<strong>''secondary'',''dg'',''enable'',''button''</strong> -> ');
             nigeLab.utils.cprintf([4, 93, 86]./255,'dark green\n');
@@ -49,13 +49,13 @@ switch nargin
             nigeLab.utils.cprintf([220, 220, 220]./255,'light gray\n');
             fprintf(1,'''onsecondary'',''onbutton'',''onsurface'',''rollover'',''enabletext'',''w'' -> ');
             nigeLab.utils.cprintf([1 1 1],'white\n');
-            fprintf(1,'<strong>''r'',''red''</strong> -> ');
+            fprintf(1,'<strong>''r'',''red'',''disableobj'',''badobj''</strong> -> ');
             nigeLab.utils.cprintf([240, 25, 25]./255,'red\n');
             fprintf(1,'<strong>''m'',''magenta''</strong> -> ');
             nigeLab.utils.cprintf([240, 25, 240]./255,'magenta\n');
             fprintf(1,'<strong>''b'',''blue''</strong> -> ');
             nigeLab.utils.cprintf([67 129 193]./255,'blue\n');
-         case {'primary','g','green','highlight','hl',1}
+         case {'primary','g','green','highlight','hl','goodobj','enableobj',1}
             Col = [30, 185, 128]./255;   % green
          case {'secondary','dg','darkgreen','button','enable',2}
             Col = [4, 93, 86]./255;      % dark green
@@ -77,7 +77,7 @@ switch nargin
             Col = [220, 220, 220]./255; % light grey
          case {'onsecondary','w','white','rollover','onbutton','enabletext','onsurface','onsfc',2.1,0.2} 
             Col = [255, 255, 255]./255; % white
-         case {'r','red'}
+         case {'r','red','disableobj','badobj'}
             Col = [240, 25, 25]./255; % red
          case {'m','magenta'}
             Col = [240, 25, 240]./255; % magenta

--- a/+nigeLab/+evt/treeSelectionChanged.m
+++ b/+nigeLab/+evt/treeSelectionChanged.m
@@ -29,12 +29,14 @@ classdef (ConstructOnLoad) treeSelectionChanged < event.EventData
    properties (GetAccess = public, SetAccess = private)
       Animal  nigeLab.Animal % Animal or array of animals in this selection
       Block   nigeLab.Block  % Block or array of blocks in this selection
-      Tank    nigeLab.Tank   % Tank associated with this selection
+      SourceType      char   % .Type corresponding to nigelObj of clicked node
       SelectionIndex  double % [animalIndex, blockIndex]
+      Tank    nigeLab.Tank   % Tank associated with this selection
+      
    end
 
    methods (Access = public)
-      function evt = treeSelectionChanged(tankObj,selectionIndex)
+      function evt = treeSelectionChanged(tankObj,selectionIndex,source)
          %TREESELECTIONCHANGED Constructor for tree selection changed event
          %
          %  tankObj = nigeLab.Tank();
@@ -43,6 +45,10 @@ classdef (ConstructOnLoad) treeSelectionChanged < event.EventData
          %  blockObj = tankObj{selectionIndex};
          %  animalObj = tankObj{unique(selectionIndex(:,1))};
          
+         if nargin < 3
+            source = '';
+         end
+         evt.SourceType = source;
          evt.Tank = tankObj;
          switch size(selectionIndex,2)
             case 0
@@ -62,7 +68,10 @@ classdef (ConstructOnLoad) treeSelectionChanged < event.EventData
                if selectionIndex(1,2)==0 % Then tank is selected
                   evt.initAll();
                   
-               else % Otherwise, relatively normal
+               elseif selectionIndex(1,3)==0
+                  evt.initAll(selectionIndex(:,2))
+                  
+               else% Otherwise, relatively normal
                   evt.SelectionIndex = selectionIndex(:,[2,3]);
                   evt.Block = tankObj{evt.SelectionIndex(:,1),...
                                       evt.SelectionIndex(:,2)};

--- a/+nigeLab/+libs/@SortUI/SortUI.m
+++ b/+nigeLab/+libs/@SortUI/SortUI.m
@@ -1,4 +1,4 @@
-classdef SortUI < matlab.mixin.SetGet
+classdef SortUI < handle & matlab.mixin.SetGet
    %SORTUI  Handle class to graphics handles for Spike Sorting Interface
    %
    %  Small "helper" class with property handles that integrate the

--- a/+nigeLab/+libs/@nigelButton/nigelButton.m
+++ b/+nigeLab/+libs/@nigelButton/nigelButton.m
@@ -1,4 +1,4 @@
-classdef nigelButton < handle
+classdef nigelButton < handle & matlab.mixin.SetGet
 %NIGELBUTTON   Buttons in format of nigeLab interface
 %
 %  NIGELBUTTON Properties:
@@ -34,12 +34,21 @@ classdef nigelButton < handle
 %           string to go into the button. In this case, the fourth input
 %           (fcn) should be provided as a function handle for ButtonDownFcn
    
-   properties (Access = public)
+   % % % PROPERTIES % % % % % % % % % %
+   % PUBLIC
+   properties (Access=public)
       SelectedColor    % Color for border change on "selected" highlight
       HoveredColor     % Color for border change on "rollover" mouse hover
    end
-
-   properties (Access = public,SetObservable = true)
+   
+   % DEPENDENT,PUBLIC
+   properties (Dependent,Access=public)
+      FontName    char = 'DroidSans'
+      FontWeight  char = 'normal'
+   end
+   
+   % SETOBSERVABLE,PUBLIC
+   properties (SetObservable,Access=public)
       Enable char = 'on'  % Is the button enabled?
       FaceColorEnable     % b.Button.FaceColor
       FaceColorDisable    % Color for face when button disabled
@@ -48,34 +57,63 @@ classdef nigelButton < handle
       String char         % String displayed on b.Label
    end
 
-   properties (Access = public, SetObservable = false)
-      Fcn     function_handle  % Function to be executed
+   % HIDDEN,PUBLIC
+   properties (Hidden,Access=public)
+      Fcn                      % Function to be executed
       Fcn_Args    cell         % (Optional) function arguments
    end
    
-   properties (Access = ?nigeLab.utils.Mouse.rollover,SetObservable = true)
+   % SETOBSERVABLE,RESTRICTED:nigeLab.utils.Mouse.rollover
+   properties (SetObservable,Access=?nigeLab.utils.Mouse.rollover)
       Hovered char = 'off'    % Does this button have mouse over it?
    end
    
-   properties (GetAccess = public,SetAccess = private,SetObservable = true)
+   % SETOBSERVABLE,PUBLIC/PROTECTED
+   properties (SetObservable,GetAccess=public,SetAccess=protected)
       Selected char = 'off'   % Is this button currently clicked
       Button  matlab.graphics.primitive.Rectangle  % Curved rectangle
       Label   matlab.graphics.primitive.Text       % Text to display
    end
    
-   properties (GetAccess = public, SetAccess = immutable)
+   % PUBLIC/IMMUTABLE
+   properties (GetAccess=public,SetAccess=immutable)
       Figure  matlab.ui.Figure           % Figure containing the object
       Group   matlab.graphics.primitive.Group  % "Container" object
       Parent  matlab.graphics.axis.Axes  % Axes container
    end
    
-   properties (Access = private)
+   % PROTECTED
+   properties (Access=protected)
       Border    matlab.graphics.primitive.Rectangle  % Border of "button"
       Listener  event.listener                   % Property event listener
    end
+   % % % % % % % % % % END PROPERTIES %
+   
+   % % % METHODS% % % % % % % % % % % %
+   % NO ATTRIBUTES (overloaded methods)
+   methods
+      % % % GET.PROPERTY METHODS % % % % % % % % % % % %
+      function value = get.FontName(obj)
+         value = obj.Label.FontName;
+      end
+      
+      function value = get.FontWeight(obj)
+         value = obj.Label.FontWeight;
+      end
+      % % % % % % % % % % END GET.PROPERTY METHODS % % %
+      
+      % % % SET.PROPERTY METHODS % % % % % % % % % % % %
+      function set.FontName(obj,value)
+         obj.Label.FontName = value;
+      end
+      
+      function set.FontWeight(obj,value)
+         obj.Label.FontWeight = value;
+      end
+      % % % % % % % % % % END SET.PROPERTY METHODS % % %
+   end
    
    % PUBLIC
-   % Class constructor and overloaded methods
    methods (Access = public)
       % Class constructor
       function b = nigelButton(container,buttonPropPairs,labPropPairs,varargin)
@@ -230,9 +268,8 @@ classdef nigelButton < handle
       end
    end
    
-   % PRIVATE
-   % Initialization methods
-   methods (Access = private, Hidden = true)
+   % HIDDEN,PROTECTED
+   methods (Hidden,Access=protected)
       function addListeners(b)
          % ADDLISTENERS  Adds all listeners to propertly .Listener
          %
@@ -379,7 +416,7 @@ classdef nigelButton < handle
                b.Label = text(b.Group,pos(1),pos(2),'',...
                   'Color',b.FontColorEnable,...
                   'FontName','Droid Sans',...
-                  'Units','normalized',...
+                  'Units','data',...
                   'FontUnits','normalized',...
                   'FontSize',0.8 * b.Button.Position(4),...
                   'Tag','Label',...
@@ -561,9 +598,8 @@ classdef nigelButton < handle
       
    end
    
-   % STATIC methods
-   % PRIVATE
-   methods (Access = private, Static = true)
+   % STATIC,PROTECTED
+   methods (Static,Access=protected)
       % Return the center coordinates based on position
       function txt_pos = getCenter(pos,xoff,yoff)
          % GETTEXTPOS  Returns the coordinates for text to go in center
@@ -667,6 +703,6 @@ classdef nigelButton < handle
          end
       end
    end
-   
+   % % % % % % % % % % END METHODS% % %
 end
 

--- a/+nigeLab/+libs/@nigelPanel/nigelPanel.m
+++ b/+nigeLab/+libs/@nigelPanel/nigelPanel.m
@@ -60,31 +60,28 @@ classdef nigelPanel < handle
       DeleteFcn  % Function handle to execute on object deletion
    end
    
-   properties (SetAccess = private, GetAccess = public)
-      Panel;      % Handle to the uipanel that is the nigelPanel basically ("inner scroll region")
-      TitleBar    % Struct for titleBox with fields: 'axes', 'r1', 'r2', and 'ann'
-   end
-   
    properties(SetObservable)
       Children    % Cell Array of nigeLab.libs.nigelPanel objects
       Color       % Struct with parameters for 'Panel','TitleText','TitleBar',and 'Parent'
       String      % Char array for string in obj.textBox.ann
       Units       % 'Normalized' or 'Pixels'
-      FontName          % Default: 'DroidSans'
-      MinTitleBarHeightPixels % Default: 20
-      TitleFontSize     % Default: 13
-      TitleFontWeight   % Default: 'bold'
-      TitleVerticalAlignment % Default: 'middle'
-      TitleAlignment    % Default: 'left'
+      FontName          char = 'DroidSans' % Default: 'DroidSans'
+      MinTitleBarHeightPixels  double = 20 % Default: 20
+      TitleFontSize     double = 13 % Default: 13
+      TitleFontWeight   char = 'bold' % Default: 'bold'
+      TitleVerticalAlignment char = 'middle' % Default: 'middle'
+      TitleAlignment    char = 'left' % Default: 'left'
       TitleBarLocation  % Location of title bar (can be 'top' or 'bot')
       TitleBarPosition  % Coordinate [px py width height] vector for titleBox position
       TitleStringX  % X-coordinate of Title String ([0 -- far left; 1 -- far right])
       TitleStringY  % Y-coordinate of middle of Title String (default: 0.5)
    end
    
-   properties (Access = private)
+   properties (GetAccess=public,SetAccess={?nigeLab.libs.nigelPanel,?nigeLab.libs.nigelBar})
       ChildName   % Cell array of names corresponding to elements of Children
       OutPanel;   % Handle to the uipanel that is an "outer" container
+      Panel;      % Handle to the uipanel that is the nigelPanel basically ("inner scroll region")
+      TitleBar    % Struct for titleBox with fields: 'axes', 'r1', 'r2', and 'ann'
       lh          % Array of listener handles
    end
    

--- a/+nigeLab/+libs/@remoteMonitor/remoteMonitor.m
+++ b/+nigeLab/+libs/@remoteMonitor/remoteMonitor.m
@@ -184,13 +184,23 @@ classdef remoteMonitor < handle
          
          % Error check on multi-job submissions
          if ~isempty(bar.job)
-            error(['nigeLab:' mfilename ':InvalidJobSubmission'],...
-               'Cannot run multiple jobs for the same Block simultaneously.');
+            nigeLab.sounds.play('pop',1.25);
+            dbstack;
+            nigeLab.utils.cprintf('Errors*',...
+               '->\t[BAD QUEUE]: Close past job for %s (click red X)\n',...
+               name);
+            nigeLab.utils.cprintf('Errors',...
+               ['\t\t* Cannot run multiple jobs for same ' ...
+               'Block simultaneously\n' ...
+               '\t\t* Successful jobs must also be cleared manually']);
+            bar = [];
+            return;
          end
 
          % Increment counter of running jobs
          bar.Progress = 0;
          bar.Name = name;
+         bar.IsRemote = ~isempty(job);
          bar.job = job;
          
          % Changing BarIndex toggles the visibility, queue position etc.

--- a/+nigeLab/+utils/buildWorkerConfigScript.m
+++ b/+nigeLab/+utils/buildWorkerConfigScript.m
@@ -157,19 +157,25 @@ end
 
       fprintf(fid,'\n%%%% Get handle to current job\n');
       fprintf(fid,'curJob = getCurrentJob;\n\n');
-      fprintf(fid,'[~,tag]=nigeLab.utils.jobTag2Pct(curJob(1).Tag);\n');
-      fprintf(fid,'curJob(1).Tag=strrep(curJob(1).Tag,tag,''Loading'');\n');
+      fprintf(fid,'if numel(curJob) > 1 %% Just in case\n\t');
+      fprintf(fid,'curJob = curJob(1);\n');
+      fprintf(fid,'elseif numel(curJob) < 1 %% Should never happen\n\t');
+      fprintf(fid,'error([''nigeLab:'' mfilename '':BadJobInit''],...\n');
+      fprintf(fid,'\t\t\t''Could not find current job.'');\n');
+      fprintf(fid,'end\n');
+      
+      fprintf(fid,'[~,tag]=nigeLab.utils.jobTag2Pct(curJob.Tag);\n');
+      fprintf(fid,'curJob.Tag=strrep(curJob(1).Tag,tag,''Loading'');\n');
       
       fprintf(fid,'%%%% Attempt to load target Block.\n');
       fprintf(fid,'blockObj = nigeLab.Block.loadRemote(targetFile);\n\n');
-      fprintf(fid,'[~,tag]=nigeLab.utils.jobTag2Pct(curJob(1).Tag);\n');
-      fprintf(fid,'curJob(1).Tag=strrep(curJob(1).Tag,tag,''Updating'');\n');
+      fprintf(fid,'delim = blockObj.Pars.Notifications.TagDelim;\n');
+      fprintf(fid,'[~,tag,name]=nigeLab.utils.jobTag2Pct(curJob.Tag,delim);\n');
+      fprintf(fid,'curJob.Tag=strrep(curJob.Tag,tag,''Updating'');\n');
       
       fprintf(fid,'%%%% Now Block is successfully loaded. Update properties\n');
       fprintf(fid,'blockObj.OnRemote = true; %% Currently on REMOTE\n');
-      fprintf(fid,'blockObj.CurrentJob = curJob(1); %% Assign JOB\n');
-%       fprintf(fid,'blockObj.updateParams(''Notifications'');\n');
-%       fprintf(fid,'blockObj.updateParams(''Queue'');\n\n');
+      fprintf(fid,'blockObj.CurrentJob = curJob; %% Assign JOB\n');
       
       fprintf(fid,'%%%% Finally, we run the queued `doAction`\n');
       fprintf(fid,'%s(blockObj); %% Runs queued `doAction (%s)`\n',...
@@ -177,8 +183,7 @@ end
       fprintf(fid,'blockObj.OnRemote = false; %% Turn off REMOTE\n');
       fprintf(fid,'blockObj.CurrentJob = []; %% Remove JOB\n');
       fprintf(fid,'save(blockObj);\n\n');
-      fprintf(fid,'[~,tag]=nigeLab.utils.jobTag2Pct(curJob(1).Tag);\n');
-      fprintf(fid,'curJob(1).Tag=strrep(curJob(1).Tag,tag,''Done'');\n');
+      fprintf(fid,'curJob.Tag=sprintf(''%%s %%s||%%g%%%%'',name,''Done'',100);\n');
       fprintf(fid,'end');
       fclose(fid);
    end

--- a/+nigeLab/+utils/shortenedName.m
+++ b/+nigeLab/+utils/shortenedName.m
@@ -23,10 +23,14 @@ end
 
 if numel(name_str) > maxChar
    nameParts = strsplit(name_str,delim);
-   if numel(nameParts) > 1
-      short_str = [nameParts{1} delim '...' delim nameParts{end}];
-   else
-      short_str = name_str;
+   switch numel(nameParts)
+      case 1
+         short_str = name_str;
+      case 2
+         short_str = [nameParts{1} delim '...' delim nameParts{end}];
+      otherwise
+         short_str = [nameParts{1} delim '...' ...
+            delim nameParts{end-1} delim nameParts{end}];
    end
 else
    short_str = name_str;

--- a/+nigeLab/@Animal/parseProbes.m
+++ b/+nigeLab/@Animal/parseProbes.m
@@ -19,7 +19,7 @@ end
 % Get all possible unique probe/channel number combinations for this Animal
 C = [];
 B = animalObj.Children(~isempty(animalObj.Children));
-B = B(animalObj.ChildMask);
+B = B([B.IsMasked]);
 for b = B
    if isempty(b)
       continue;

--- a/+nigeLab/@Block/Block.m
+++ b/+nigeLab/@Block/Block.m
@@ -74,8 +74,8 @@ classdef Block < nigeLab.nigelObj
    %     Empty - Create an Empty BLOCK object or array
    
    % % % PROPERTIES % % % % % % % % % %   
-   % HIDDEN, PUBLIC
-   properties (Hidden,Access=public)
+   % HIDDEN,TRANSIENT,PUBLIC
+   properties (Hidden,Transient,Access=public)
       CurrentJob                % parallel.job.MJSCommunicatingJob
    end
    

--- a/+nigeLab/@Block/doAutoClustering.m
+++ b/+nigeLab/@Block/doAutoClustering.m
@@ -43,6 +43,8 @@ end
 blockObj.reportProgress(str,0,'toWindow');
 curCh = 0;
 for iCh = chan
+   curCh = curCh+1;
+   
    % load spikes and classes
    inspk = blockObj.getSpikeFeatures(iCh,unit);
    if isempty(inspk)
@@ -82,15 +84,14 @@ for iCh = chan
    saveClusters(blockObj,classes,iCh,temp);
    
    % report progress to the user
-   curCh = curCh+1;
-   pct = round((curCh/numel(chan)) * 100);
+   pct = round((curCh/numel(chan)) * 90);
    blockObj.updateStatus('Clusters',true,iCh);
    blockObj.reportProgress(str,pct,'toWindow');
    blockObj.reportProgress(par.MethodName,pct,'toEvent',par.MethodName);
 end
 if blockObj.OnRemote
    str = 'Saving-Block';
-   blockObj.reportProgress(str,100,'toWindow',str);
+   blockObj.reportProgress(str,95,'toWindow',str);
 else
    blockObj.save;
    linkStr = blockObj.getLink('Clusters');

--- a/+nigeLab/@Block/doLFPExtraction.m
+++ b/+nigeLab/@Block/doLFPExtraction.m
@@ -36,7 +36,9 @@ else
 end
 fType = blockObj.FileType{strcmpi(blockObj.Fields,'LFP')};
 curCh = 0;
+nCh = numel(blockObj.Mask);
 for iCh=blockObj.Mask
+   curCh = curCh + 1;
    % Get the values from Raw DiskData, and decimate:
    data=double(blockObj.Channels(iCh).Raw(:));
    for jj=1:numel(DecimateCascadeM)
@@ -50,16 +52,14 @@ for iCh=blockObj.Mask
    blockObj.Channels(iCh).LFP = nigeLab.libs.DiskData(fType,...
       fName,data,'access','w');
    blockObj.Channels(iCh).LFP = lockData(blockObj.Channels(iCh).LFP);
-
-   curCh = curCh + 1;
-   pct = round(curCh/numel(blockObj.Mask) * 100);
+   pct = round(curCh/nCh*90);
    blockObj.reportProgress(str,pct,'toWindow');
    blockObj.reportProgress('Decimating.',pct,'toEvent');
    blockObj.updateStatus('LFP',true,iCh);
 end
 if blockObj.OnRemote
    str = 'Saving-Block';
-   blockObj.reportProgress(str,100,'toWindow',str);
+   blockObj.reportProgress(str,95,'toWindow',str);
 else
    blockObj.save;
    linkStr = blockObj.getLink('LFP');

--- a/+nigeLab/@Block/doReReference.m
+++ b/+nigeLab/@Block/doReReference.m
@@ -41,7 +41,9 @@ end
 %% COMPUTE THE MEAN FOR EACH PROBE
 blockObj.reportProgress('Computing-CAR',0,'toWindow');
 curCh = 0;
+nCh = numel(blockObj.Mask);
 for iCh = blockObj.Mask
+   curCh = curCh + 1;
    if ~doSuppression
       % Filter and and save amplifier_data by probe/channel
       iProbe = blockObj.Channels(iCh).probe;
@@ -52,17 +54,18 @@ for iCh = blockObj.Mask
       warning('STIM SUPPRESSION method not yet available.');
       return;
    end
-   curCh = curCh + 1;
-   pct = round(100 * (curCh / numel(blockObj.Mask)));
-   PCT = round((pct/100) * 20); 
+   
+   PCT = round(20*curCh/nCh);
    blockObj.reportProgress('Computing-CAR',PCT,'toWindow');
    blockObj.reportProgress('Computing-CAR',PCT,'toEvent','Computing-CAR');
 end
 
 %% SAVE EACH PROBE REFERENCE TO THE DISK
 refMeanFile = cell(numel(probe),1);
-
 for iProbe = 1:nProbes
+   PCT = 20 + round(10 * iProbe/nProbes);
+   blockObj.reportProgress('Computing-CAR',PCT,'toWindow');
+   blockObj.reportProgress('Computing-CAR',PCT,'toEvent','Computing-CAR');
    refName = fullfile(sprintf(...
       strrep(blockObj.Paths.CAR.file,'\','/'),...
       num2str(probe(iProbe)),'REF'));
@@ -80,6 +83,7 @@ else
 end
 curCh = 0;
 for iCh = blockObj.Mask
+   curCh = curCh + 1;
    % Do re-reference
    data = doCAR(blockObj.Channels(iCh),...
       refMean(blockObj.Channels(iCh).probe));
@@ -98,9 +102,8 @@ for iCh = blockObj.Mask
       refMeanFile{blockObj.Channels(iCh).probe});
    
    % Update user
-   curCh = curCh + 1;
-   pct = 100 * (curCh / numel(blockObj.Mask));
-   PCT = 20 + round((pct/100) * 80);
+   
+   PCT = 30 + round(60 * curCh/nCh);
    blockObj.reportProgress(str,PCT,'toWindow'); 
    blockObj.reportProgress('Removing-CAR',PCT,'toEvent','Removing-CAR');
    blockObj.updateStatus('CAR',true,iCh);
@@ -108,7 +111,7 @@ end
 
 if blockObj.OnRemote
    str = 'Saving-Block';
-   blockObj.reportProgress(str,100,'toWindow',str);
+   blockObj.reportProgress(str,95,'toWindow',str);
 else
    blockObj.save;
    linkStr = blockObj.getLink('CAR');

--- a/+nigeLab/@Block/doSD.m
+++ b/+nigeLab/@Block/doSD.m
@@ -38,7 +38,7 @@ end
 blockObj.reportProgress(str,0,'toWindow');
 curCh = 0;
 for iCh = blockObj.Mask
-   
+   curCh = curCh + 1;
    % Parse file-name information
    pNum  = num2str(blockObj.Channels(iCh).probe);
    chNum = blockObj.Channels(iCh).chStr;
@@ -58,7 +58,6 @@ for iCh = blockObj.Mask
    end
    
    % Status updates done in saveChannelSpikingEvents
-   curCh = curCh + 1;
    pct = round(curCh/numel(blockObj.Mask) * 100);
    blockObj.reportProgress(str,pct,'toWindow');
    blockObj.reportProgress('Spike-Detection.',pct,'toEvent','Spike-Detection');

--- a/+nigeLab/@Block/doUnitFilter.m
+++ b/+nigeLab/@Block/doUnitFilter.m
@@ -39,7 +39,10 @@ end
 
 blockObj.reportProgress(str,0,'toWindow','Filtering');
 
+curCh = 0;
+nCh = numel(blockObj.Mask);
 for iCh = blockObj.Mask   
+   curCh = curCh + 1;
    if blockObj.Channels(iCh).Raw.length <= nfact
       continue; % It should leave the updateFlag as false for this channel
    end
@@ -71,15 +74,14 @@ for iCh = blockObj.Mask
    end
    
    blockObj.updateStatus('Filt',true,iCh);
-   curCh = find(blockObj.Mask == iCh,1,'first');
-   pct = round(curCh/numel(blockObj.Mask) * 100);
+   pct = round(curCh/nCh * 90);
    blockObj.reportProgress(str,pct,'toWindow','Filtering');
    blockObj.reportProgress('Filtering.',pct,'toEvent');
 end
 
 if blockObj.OnRemote
    str = 'Saving-Block';
-   blockObj.reportProgress(str,100,'toWindow',str);
+   blockObj.reportProgress(str,95,'toWindow',str);
 else
    blockObj.save;
    linkStr = blockObj.getLink('Filt');

--- a/+nigeLab/@Block/intan2Block.m
+++ b/+nigeLab/@Block/intan2Block.m
@@ -53,7 +53,6 @@ if isempty(s)
    blockObj.reportProgress('<strong>No files found!</strong> Extraction aborted ::',...
       100,'toWindow','Aborted');
    blockObj.reportProgress('',100,'toEvent');
-   delete(lh);
    return;
 end
 filesize = s.bytes;

--- a/+nigeLab/@Block/list.m
+++ b/+nigeLab/@Block/list.m
@@ -45,6 +45,7 @@ catch
 end
 
 info.Key = {num2str(keyIdx)};
+info.Enabled = blockObj.IsMasked;
 info.Recording_date=DateTime;
 % info.LengthInMinutes=minutes(seconds((blockObj.Samples./blockObj.SampleRate)));
 info.Duration = blockObj.Duration;


### PR DESCRIPTION
# Updated Pull Request #
Reference #56 and #57; this is just to keep the branches from getting too divergent. Also there are some bug-fixes in this one, which is relatively small compared to the other merges.

# Main Addition #
* Animals can now be "masked" as well
  + Batch runs are now facilitated by being able to Enable/Disable subsets of tree nodes, so that running from the level above only applies the `doMethod` to desired subset (e.g. toggle off two animals that are already processed, then select tank)

## Bugfix List ##
* Bugfix for `getFooter` method array indexing on blockObj and animalObj
* Fix issue where DashBoard constructor was improperly adding listeners to a deleted object handle for some odd syntax reason.
* Update plotRecapTable() so that "non-enabled" blocks show up as darker shades
* Set .CurrentJob nigeLab.Block property attribute Transient to true (so it is not saved, which was throwing warnings on the remote).
* Fix load issue in case where .Type was not properly associated with matfile
* Minor fix on .nigelProgress class
* Fixed bug where mask was being incorrectly assigned

## Update List ##
* blockObj.list() method now outputs additional column: `IsMasked`
* Update how job notifications are parsed for niche cases where job was completed but notification gave incorrect error alert.
  + Includes modifications to `doMethods` for channel indexing
* Change buttons in `nigelBar` "titlebar" to be `nigeLab.libs.nigelButton` as well.
* Updated how `treeSelectionFcn` in DashBoard gets items:
  + Now automatically de-selects "non-enabled" Blocks or Animals if multiple nodes are selected (to make batch execution easier when Child masks are in use).
* Cosmetic changes:
  + Cosmetic changes to DashBoard regarding Enable/Disable mask status
  + Fix so that YAxis of RecapPlot shows keys with scaling fontsize if more rows are present.
  + Update color scheme naming and how it is associated with DashBoard