### PR TITLE
Re-Open Issue #63

### DIFF
--- a/+nigeLab/@Sort/Sort.m
+++ b/+nigeLab/@Sort/Sort.m
@@ -68,23 +68,43 @@ classdef Sort < handle
          %  sortObj = nigeLab.Sort;
          %  sortObj = nigeLab.Sort(nigelObj);                       
          
-         % Initialize parameters
-         if ~initParams(sortObj)
-            error(['nigeLab:' mfilename ':BadInit'],...
-                  'Could not set parameters for sortObj.');
-         end
-         
          % Initialize input data
          if nargin > 0
+            if isnumeric(nigelObj) % Initialize
+               dims = nigelObj;
+               sortObj = repmat(sortObj,dims);
+               return;
+            end
+            
+            % Initialize parameters
+            if ~initParams(sortObj,nigelObj)
+               error(['nigeLab:' mfilename ':BadInit'],...
+                     'Could not set parameters for sortObj.');
+            end
+            
             if ~initData(sortObj,nigelObj)
                error(['nigeLab:' mfilename ':BadInit'],...
                   'sortObj array not created successfully.');
             end
-         else
-            if ~initData(sortObj)
-               error(['nigeLab:' mfilename ':BadInit'],...
-                  'sortObj array not created successfully.');
-            end
+%          else       % Note: it is no longer possible to call `Sort`
+%                     %       constructor from Command Window directly; has
+%                     %       to be called via a `nigelObj` method
+%                     %       2020-01-20 -MM
+%
+%             % Initialize parameters
+%             if ~initParams(sortObj)
+%                error(['nigeLab:' mfilename ':BadInit'],...
+%                      'Could not set parameters for sortObj.');
+%             end
+%             % And then initialize data
+%             if ~initData(sortObj)
+%                error(['nigeLab:' mfilename ':BadInit'],...
+%                   'sortObj array not created successfully.');
+%             end
+         else % Therefore, if it is given without inputs, it is for init
+            sortObj = nigeLab.Sort([0,0]); % Empty
+            close(gcf);
+            return;
          end
          
          % Initialize graphical interface
@@ -98,7 +118,7 @@ classdef Sort < handle
       end
    end
       
-   % NO ATTRIBUTES (contructor & overloaded methods)
+   % NO ATTRIBUTES (overloaded methods)
    methods      
       % Overloaded `delete` method
       function delete(sortObj)
@@ -188,7 +208,7 @@ classdef Sort < handle
    
    % PROTECTED
    methods (Access=protected)      
-      flag = initParams(sortObj); % Initialize general parameters
+      flag = initParams(sortObj,nigelObj); % Initialize general parameters
       flag = initData(sortObj,nigelObj); % Initialize data structures
       flag = initUI(sortObj); % Initializes spike scoring UI parameters
       

--- a/+nigeLab/@Sort/initParams.m
+++ b/+nigeLab/@Sort/initParams.m
@@ -1,25 +1,39 @@
-function flag = initParams(sortObj)
-%% INITPARAMS  Initialize parameters structure for Spike Sorting UI.
+function flag = initParams(sortObj,nigelObj)
+%INITPARAMS  Initialize parameters structure for Spike Sorting UI.
 %
 %  flag = INITPARAMS(sortObj);
-%
-% By: Max Murphy  v3.0    01/07/2019 Port to object-oriented architecture.
-%                 v2.0    10/03/2017 Added ability to handle multiple input
-%                                    probes with redundant channel labels.
-%                 v1.0    08/18/2017 Original version (R2017a)
+%  --> Load `Sort` defaults from nigeLab.defaults.Sort();
+%  
+%  flag = INITPARAMS(sortObj,nigelObj);
+%  --> Load `Sort` parameters from nigelObj directly
 
-%% MODIFY SORT CLASS OBJECT PROPERTIES HERE
+% MODIFY SORT CLASS OBJECT PROPERTIES HERE
 flag = false;
 
-pars = nigeLab.defaults.Sort();
+if nargin < 2
+   pars = nigeLab.defaults.Sort();
+   flag = true;
+else
+   pars = cell(size(nigelObj)); % In case it is array
+   [pars{:}] = getParams(nigelObj,'Sort');
+   pars(cellfun(@isempty,pars)) = [];
+   if isempty(pars)
+      warning(['[INITPARAMS]: Array of %g %g objects does not ' ...
+         'have `Sort` parameters initialized yet.\n'],...
+         numel(nigelObj),class(nigelObj));
+      return;
+   elseif isequal(pars{:})
+      flag = true;
+   else
+      warning(['[INITPARAMS]: Array of %g %g objects does not ' ...
+         'contain identical `Sort` parameters for each object.\n'],...
+         numel(nigelObj),class(nigelObj));
+      return;
+   end
+end
 
-%% COULD ADD PARSING FOR PROPERTY VALIDITY HERE?
-% To look into for future...
-%
-%  e.g. Check that "SDMAX" is numeric, and greater than "SDMIN" etc...
-
-%% UPDATE PARS PROPERTY
+% UPDATE PARS PROPERTY
 sortObj.pars = pars;
-flag = true;
+
 
 end


### PR DESCRIPTION
# Bugfix: Issue #63 
* Re-opened issue #63 as it was persisting (thought I had fixed it).

## Description
* When `nigeLab.nigelObj.GUI`  and `nigeLab.nigelObj.GUIContainer` are assigned the `nigeLab.libs.DashBoard` object in `nigeLab.nigelObj/requestNigelDash()`, something about the assignment causes the extra figure to be generated. 

## Strategy
* Add class validator on those properties. 
  + Because `nigeLab.libs.DashBoard` (and `nigeLab.Sort`) couldn't be constructed without input arguments, their constructors have been changed since they are only constructed via methods of `nigeLab.nigelObj` at this point. 
  + Now they can be constructed with no inputs (as empty handles).

## Updates
* `nigeLab.libs.DashBoard`
  + Now can be constructed without input arguments, so it works as a property validator.

* `nigeLab.Sort`
  + Now can be constructed without input arguments, so it works as a property validator.
  + Updated `initParams()` method to take `nigelObj` instead of load `Sort` parameters directly from `+defaults` file.
