### PR TITLE
Fix nigelObj.get.Version

### DIFF
--- a/+nigeLab/@nigelObj/nigelObj.m
+++ b/+nigeLab/@nigelObj/nigelObj.m
@@ -2139,12 +2139,17 @@ classdef nigelObj < handle & ...
          
          value = 'unknown';     
          if isunix
-            setenv('GIT_DIR',nigeLab.utils.getNigelPath('UNC'));
+            nigelPath = nigeLab.utils.getNigelPath('UNC');
+            nigelPath = [nigelPath '/.git'];
+            setenv('GIT_DIR',nigelPath);
          else
-            setenv('GIT_DIR',nigeLab.utils.getNigelPath());
+            nigelPath = nigeLab.utils.getNigelPath();
+            nigelPath = strrep(nigelPath,'\','/');
+            nigelPath = [nigelPath '/.git'];
+            setenv('GIT_DIR',nigelPath);
          end
          syscmdstr = sprintf(...
-            'git describe --abbrev=0 --tags --candidates=1');
+               'git describe --abbrev=0 --tags --candidates=1');
          [status,cmdout] = system(syscmdstr);
          if status ~= 0
             return;


### PR DESCRIPTION
Now correctly sets the Matlab Environment variable 'GIT_DIR' to be the /.git folder, rather than the base `nigeLab` folder (only tested in Windows, uses system command).
* nigelObj.Version should return the most-recent version tag.
