### PR TITLE
Make setup and demo easier.

### DIFF
--- a/+nigeLab/setup/demo/demo_nigeLab.m
+++ b/+nigeLab/setup/demo/demo_nigeLab.m
@@ -1,4 +1,4 @@
-%% nigeLab - Demo command line
+%%DEMO Script to run `nigeLab` demonstration/test
 clear
 clc
 

--- a/+nigeLab/setup/install_nigeLab.m
+++ b/+nigeLab/setup/install_nigeLab.m
@@ -39,6 +39,9 @@ installedToolbox = matlab.addons.toolbox.installToolbox(toolboxFile);
 cd ..
 cd ..
 addpath(pwd)
-disp('ePhys_packages and thus nigeLab added to path')
+disp('Repository folder (and thus +nigeLab) added to path')
 % Add that folder plus all subfolders to the path.
 % addpath(genpath(setup_folder));
+
+%% copy `demo_nigeLab.m` to top-level and rename
+copyfile(fullfile(pwd,'+nigeLab','setup','demo','demo_nigeLab.m'),fullfile(pwd,'demo.m'),'f');

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.asv
+demo.m
+flags/*.yaml
 
 nigelCARperf\.pdf
 

--- a/flags/README.md
+++ b/flags/README.md
@@ -1,0 +1,8 @@
+# Flags #
+_Folder for abstract (dev-related) "flags" related to installation status, etc._
+
+## Contents ##
+Everything in this folder should be a `*.yaml` file (except this markdown document).
+
+* `installed.yaml` - Put here when installation is run via `install.m`
+  + This is checked by `install.m` and if it exists, then packages are not re-installed needlessly.

--- a/install.m
+++ b/install.m
@@ -1,0 +1,37 @@
+%INSTALL Script to install nigeLab on first-time use.
+
+if exist(fullfile(pwd,'installed.yaml'),'file')==0
+   cd(fullfile(pwd,'+nigeLab','setup'));
+   install_nigeLab;
+   write_install_indicator(pwd,'flags');
+   disp('nigeLab installed successfully!');
+else
+   disp('nigeLab has already been installed! Re-install skipped.');
+end
+   
+function write_install_indicator(p,f)
+%WRITE_INSTALL_INDICATOR Write indicator file to prevent multi-install
+%
+%  write_install_indicator(p,f);
+%
+% Inputs
+%  p - Path of repository
+%  f - Path of "flags" folder (should be folder in repository)
+%
+% Output
+%  -- none --
+%  Writes '.installed' file wherever `p` points, which can be checked on by
+%  other things to make sure that `nigeLab` has actually been installed.
+
+loc = fullfile(p,f);
+if exist(loc,'dir')==0
+   mkdir(loc);
+end
+fid = fopen(fullfile(loc,'installed.yaml'),'w');
+fprintf(fid,[...
+      'Installed: "%s" #Time when `install.m` completed.\n' ...
+      'Repository_Folder: "%s" #Folder containing `+nigeLab`.\n' ...
+   ],...
+   string(datetime),p);
+fclose(fid);
+end


### PR DESCRIPTION
Added `install.m` at top-level of repository, which navigates to correct location and runs `install_nigeLab.m`. It also generates a "flags" folder at the top level that should contain only yaml files indicating installation steps or whatever have been completed and possibly containing some metadata in the file itself (such as the install date).
