### PR TITLE
Add downsampling of filtered data

### DIFF
--- a/+nigeLab/+defaults/Filt.m
+++ b/+nigeLab/+defaults/Filt.m
@@ -47,6 +47,9 @@ APASS  = 0.1;        % Passband Ripple (dB)
 METHOD = 'ellip';    % filter type
 ORDER = 4;
 
+DOWNSAMPLE_AUTO = true;    % set true to downsample data after filtering
+DOWNSAMPLE_FREQ = 5000;   % new sampling frequency (30 kHz --> 5 kHz)
+
 STIM_SUPPRESS = true;  % set true to do stimulus artifact suppression
 STIM_BLANK = [1 3];     % milliseconds prior and after to blank on stims
 STIM_P_CH = [nan, nan]; % [probe #, channel #] for channel delivering stims
@@ -71,6 +74,9 @@ pars.FPASS2 = FPASS2;
 pars.ASTOP  = ASTOP;         
 pars.APASS  = APASS;   
 pars.ORDER  = ORDER;
+
+pars.DOWNSAMPLE_AUTO = DOWNSAMPLE_AUTO;
+pars.DOWNSAMPLE_FREQ = DOWNSAMPLE_FREQ;
 
 pars.METHOD = METHOD;
 

--- a/+nigeLab/@Block/doUnitFilter.m
+++ b/+nigeLab/@Block/doUnitFilter.m
@@ -80,12 +80,15 @@ for iCh = blockObj.Mask
       % Downsample data to reduce their size, since they went through
       % filtering. Params are defined in defaults.Filt
       if pars.DOWNSAMPLE_AUTO
+         minFreqNyqst = round(2.2*pars.FPASS2);
          if mod(pars.DOWNSAMPLE_FREQ, 1) == 0
-            if pars.DOWNSAMPLE_FREQ >= pars.FPASS2
+            if pars.DOWNSAMPLE_FREQ >= minFreqNyqst
                data = resample(data, pars.DOWNSAMPLE_FREQ, blockObj.Channels(iCh).fs);
                blockObj.SampleRate = pars.DOWNSAMPLE_FREQ;
             else
-               warning(['The downsampling frequency is smaller than ', num2str(pars.FPASS2), ' Hz. Skipped.']);
+               warning(sprintf('The downsampling frequency is smaller than %dHz.\n Downsampling at %dHz.',minFreqNyqst,minFreqNyqst);
+               data = resample(data, minFreqNyqst, blockObj.Channels(iCh).fs);
+               blockObj.SampleRate = minFreqNyqst;
             end
          else
             warning('The downsampling frequency must be an integer. Skipped.');

--- a/+nigeLab/@Block/doUnitFilter.m
+++ b/+nigeLab/@Block/doUnitFilter.m
@@ -76,6 +76,21 @@ for iCh = blockObj.Mask
       for ii=1:L
          data = (ff(b,a,data,nfact,zi));
       end
+
+      % Downsample data to reduce their size, since they went through
+      % filtering. Params are defined in defaults.Filt
+      if pars.DOWNSAMPLE_AUTO
+         if mod(pars.DOWNSAMPLE_FREQ, 1) == 0
+            if pars.DOWNSAMPLE_FREQ >= pars.FPASS2
+               data = resample(data, pars.DOWNSAMPLE_FREQ, blockObj.Channels(iCh).fs);
+               blockObj.SampleRate = pars.DOWNSAMPLE_FREQ;
+            else
+               warning(['The downsampling frequency is smaller than ', num2str(pars.FPASS2), ' Hz. Skipped.']);
+            end
+         else
+            warning('The downsampling frequency must be an integer. Skipped.');
+         end
+      end
       
       blockObj.Channels(iCh).Filt = DiskData(...
          fType,fName,data,...


### PR DESCRIPTION
This PR implements the downsampling of filtered data.
As raw data are filtered by a band-pass filter in the 300-300 Hz range, the filtered signal can be resampled at frequencies
slightly larger than 3000 Hz, such as 5000 Hz, in order to reduce its size in memory.
Note that the `SampleRate` attribute of the `Block` class is changed accordingly, while the `fs` property of each channel is
left unchanged at 30000 Hz (the original sampling frequency). This produces a potential inconsistency and it might therefore be better to ensure the same value between `Block.SampleRate` and the `fs` attribute of channels.